### PR TITLE
Fixed enabling of session persistence via the API, refactored to code to allow setting of persistence type other than HTTP_COOKIE

### DIFF
--- a/lib/cloudlb/exception.rb
+++ b/lib/cloudlb/exception.rb
@@ -43,6 +43,8 @@ module CloudLB
     end
     class MissingArgument             < StandardError # :nodoc:
     end
+    class InvalidArgument             < StandardError # :nodoc:
+    end
     class Authentication              < StandardError # :nodoc:
     end
     class Connection                  < StandardError # :nodoc:


### PR DESCRIPTION
Note that the default API was preserved, I've added an explicit set method that accepts a persistence_type and call that instead.
